### PR TITLE
Update cookie-httponly helptext with better info

### DIFF
--- a/audits/cookie-httponly.js
+++ b/audits/cookie-httponly.js
@@ -1,8 +1,5 @@
 const Audit = require('lighthouse').Audit;
 
-const MAX_SEARCHABLE_TIME = 4000;
-
-
 class CookieHttpOnlyAudit extends Audit {
   static get meta() {
     return {
@@ -12,8 +9,6 @@ class CookieHttpOnlyAudit extends Audit {
       failureDescription: 'Cookies are not HttpOnly',
       helpText: 'Using the HttpOnly flag when generating a cookie helps mitigate the risk of client side script accessing the protected cookie. ' +
           '[Learn more](https://www.owasp.org/index.php/HttpOnly)',
-
-      // The name of the custom gatherer class that provides input to this audit.
       requiredArtifacts: ['RequestHeaders']
     };
   }
@@ -21,7 +16,6 @@ class CookieHttpOnlyAudit extends Audit {
   static audit(artifacts) {
     const headers = artifacts.RequestHeaders
     const setCookieHeader = headers['set-cookie']
-
     const httpOnly = /HttpOnly/.test(setCookieHeader) || !setCookieHeader
 
     return {
@@ -31,4 +25,4 @@ class CookieHttpOnlyAudit extends Audit {
   }
 }
 
-module.exports = CookieHttpOnlyAudit
+module.exports = CookieHttpOnlyAudit;

--- a/audits/cookie-httponly.js
+++ b/audits/cookie-httponly.js
@@ -8,8 +8,10 @@ class CookieHttpOnlyAudit extends Audit {
     return {
       category: 'PageSecurity',
       name: 'cookie-httpOnly-audit',
-      description: 'Cookies are httpOnly',
-      helpText: 'For more information visit https://www.owasp.org/index.php/HttpOnly',
+      description: 'Cookies are HttpOnly',
+      failureDescription: 'Cookies are not HttpOnly',
+      helpText: 'Using the HttpOnly flag when generating a cookie helps mitigate the risk of client side script accessing the protected cookie. ' +
+          '[Learn more](https://www.owasp.org/index.php/HttpOnly)',
 
       // The name of the custom gatherer class that provides input to this audit.
       requiredArtifacts: ['RequestHeaders']


### PR DESCRIPTION
and 
* always PascalCase HttpOnly
* add failure description
* change link to markdown format
* remove boilerplate code