### PR TITLE
Add meta-generator audit

### DIFF
--- a/audits/meta-generator.js
+++ b/audits/meta-generator.js
@@ -13,7 +13,7 @@ class MetaGeneratorAudit extends Audit {
           'web framework fingerprinting. The tag exposes known vulnerabilities ' +
           'in unpatched versions as well as specific misconfigurations in the ' +
           'framework and known file structures. ' +
-          '[Learn more](https://goo.gl/67tR4s).',
+          '[Learn more](https://goo.gl/XhsuhC).',
       requiredArtifacts: ['MetaGenerator']
     };
   }

--- a/audits/meta-generator.js
+++ b/audits/meta-generator.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const Audit = require('lighthouse').Audit;
+
+class MetaGeneratorAudit extends Audit {
+  static get meta() {
+    return {
+      category: 'PageSecurity',
+      name: 'meta-generator',
+      description: 'Page has no `<meta name="generator">`',
+      failureDescription: 'Page has `<meta name="generator">` set to',
+      helpText: 'Make sure to remove the generator meta tag to prevent ' +
+          'web framework fingerprinting. The tag exposes known vulnerabilities ' +
+          'in unpatched versions as well as specific misconfigurations in the ' +
+          'framework and known file structures. ' +
+          '[Learn more](https://goo.gl/67tR4s).',
+      requiredArtifacts: ['MetaGenerator']
+    };
+  }
+
+  static audit(artifacts) {
+    const generatorValue = artifacts.MetaGenerator;
+    const hasNoGenerator = (typeof generatorValue !== 'string');
+
+    if (hasNoGenerator) {
+        return { 
+            rawValue: true 
+        };
+    }
+    
+    return {
+      displayValue: generatorValue,
+      rawValue: hasNoGenerator
+    };
+  }
+}
+
+module.exports = MetaGeneratorAudit;

--- a/config/config.js
+++ b/config/config.js
@@ -19,9 +19,10 @@ module.exports = {
   passes: [{
     passName: 'defaultPass',
     gatherers: [
-      'request-headers',
       'csp-meta',
-      'redirect'
+      'meta-generator',
+      'redirect',
+      'request-headers',
     ].map(basename => path.join(dirs.gatherers, basename)),
   }],
 
@@ -34,6 +35,7 @@ module.exports = {
         'cookie-httponly',
         'cookie-secure',
         'redirect',
+        'meta-generator',
     ].map(basename => path.join(dirs.audits, basename)),
     './audits/is-on-https',
     './audits/dobetterweb/external-anchors-use-rel-noopener'
@@ -52,7 +54,8 @@ module.exports = {
         {id: 'cookie-secure-audit', weight: 1},
         {id: 'http-redirect-audit', weight: 1},
         {id: 'is-on-https', weight: 1},
-        {id: 'external-anchors-use-rel-noopener', weight: 0}
+        {id: 'meta-generator', weight: 1},
+        {id: 'external-anchors-use-rel-noopener', weight: 0},
       ]
     }
   }

--- a/gather/meta-generator.js
+++ b/gather/meta-generator.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const Gatherer = require('lighthouse').Gatherer
+
+class MetaGenerator extends Gatherer {
+
+  /**
+   * @param {{driver: !Object}} options Run options
+   * @return {!Promise<?string>} The value of the viewport meta's content attribute, or null
+   */
+  afterPass(options) {
+    const driver = options.driver;
+
+    return driver.querySelector('head meta[name="generator"]')
+      .then(node => node && node.getAttribute('content'));
+  }
+}
+
+module.exports = MetaGenerator;

--- a/gather/meta-generator.js
+++ b/gather/meta-generator.js
@@ -6,7 +6,7 @@ class MetaGenerator extends Gatherer {
 
   /**
    * @param {{driver: !Object}} options Run options
-   * @return {!Promise<?string>} The value of the viewport meta's content attribute, or null
+   * @return {!Promise<?string>} The value of the generator meta's content attribute, or null
    */
   afterPass(options) {
     const driver = options.driver;


### PR DESCRIPTION
Audit tests for fingerprinting based on `<meta name="generator">`

Result if passing (used `https://www.voorhoede.nl`):

<img width="385" alt="screen shot 2017-08-12 at 12 15 09" src="https://user-images.githubusercontent.com/1516059/29240011-78f22d0c-7f5c-11e7-83ce-790454985a4d.png">

Result if failing (used `https://www.veiligbankieren.nl` ironically):

<img width="716" alt="screen shot 2017-08-12 at 12 35 33" src="https://user-images.githubusercontent.com/1516059/29240012-78f6823a-7f5c-11e7-9c26-716144a6e26e.png">

Note: used URL minifier for link to OWASP page as Lighthouse doesn't play well with URLs containing `)`.