### PR TITLE
[WIP] Add SSL Grade audit

### DIFF
--- a/audits/ssl-grade.js
+++ b/audits/ssl-grade.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const Audit = require('lighthouse').Audit;
+
+const STRONG_SLL_GRADES = ['A+', 'A', 'A-'];
+const GRADE_PERCENTAGES = { // source https://en.wikipedia.org/wiki/Academic_grading_in_the_United_States#Numerical_and_Letter_grades
+    'A+': { min: 100, max: 100 },
+    'A' : { min:  93, max:  99 },
+    'A-': { min:  90, max:  92 },
+    'B+': { min:  87, max:  89 },
+    'B' : { min:  83, max:  86 },
+    'B-': { min:  80, max:  82 },
+    'C+': { min:  77, max:  79 },
+    'C' : { min:  73, max:  76 },
+    'C-': { min:  70, max:  72 },
+    'D+': { min:  67, max:  69 },
+    'D' : { min:  63, max:  66 },
+    'D-': { min:  60, max:  62 },
+    'F' : { min:   0, max:  59 },
+}
+
+const getLowestGrade = grades => grades.reduce((lowest, grade) => {
+    if (GRADE_PERCENTAGES[grade].min < GRADE_PERCENTAGES[lowest].min) {
+        return grade;
+    }
+    return lowest;
+});
+
+class SslGradeAudit extends Audit {
+  static get meta() {
+    return {
+      category: 'PageSecurity',
+      name: 'ssl-grade',
+      description: 'Site has strong SSL configuration',
+      failureDescription: 'Site has poor SSL configuration',
+      helpText: 'The security level of a site\'s connection with its servers depends on the ' +
+          'strength of the SSL configuration, which includes the certificates, protocol support, ' +
+          'key exchange and cipher strength. ' +
+          'This audit grades servers using the [SSL Test by SSL Labs](https://www.ssllabs.com/ssltest/). ' +
+          'For details on the grading method see the [SSL Server Rating Guide](https://github.com/ssllabs/research/wiki/SSL-Server-Rating-Guide#methodology-overview).',
+      requiredArtifacts: ['SslGrade'],
+    };
+  }
+
+  static audit(artifacts) {
+    const report = artifacts.SslGrade;
+
+    if (report.status !== 'READY') {
+        return {
+            debugString: 'SSL test failed. Try manually on [www.ssllabs.com/ssltest/](https://www.ssllabs.com/ssltest/)',
+            rawValue: false,
+        }
+    }
+
+    const grades = report.endpoints.map(endpoint => endpoint.grade);
+    const lowestGrade = getLowestGrade(grades);
+
+    const tableHeadings = [
+        { key: 'server', itemType: 'text', text: 'Server' },
+        { key: 'grade', itemType: 'text', text: 'Grade' }
+    ];
+    const tableItems = report.endpoints.map(endpoint => ({
+        server: endpoint.serverName ? `${endpoint.ipAddress} (${endpoint.serverName})` : endpoint.ipAddress,
+        grade: endpoint.grade
+    }));
+    const details = Audit.makeTableDetails(tableHeadings, tableItems);
+
+    return {
+        displayValue: `Grade ${lowestGrade}`,
+        rawValue: STRONG_SLL_GRADES.includes(lowestGrade),
+        details
+    }
+  }
+}
+
+module.exports = SslGradeAudit;

--- a/config/config.js
+++ b/config/config.js
@@ -21,7 +21,8 @@ module.exports = {
     gatherers: [
       'request-headers',
       'csp-meta',
-      'redirect'
+      'redirect',
+      'ssl-grade',
     ].map(basename => path.join(dirs.gatherers, basename)),
   }],
 
@@ -34,6 +35,7 @@ module.exports = {
         'cookie-httponly',
         'cookie-secure',
         'redirect',
+        'ssl-grade',
     ].map(basename => path.join(dirs.audits, basename)),
     './audits/is-on-https',
     './audits/dobetterweb/external-anchors-use-rel-noopener'
@@ -52,7 +54,8 @@ module.exports = {
         {id: 'cookie-secure-audit', weight: 1},
         {id: 'http-redirect-audit', weight: 1},
         {id: 'is-on-https', weight: 1},
-        {id: 'external-anchors-use-rel-noopener', weight: 0}
+        {id: 'external-anchors-use-rel-noopener', weight: 0},
+        {id: 'ssl-grade', weight: 1}
       ]
     }
   }

--- a/gather/ssl-grade.js
+++ b/gather/ssl-grade.js
@@ -1,0 +1,50 @@
+const Gatherer = require('lighthouse').Gatherer
+const ssllabs = require('node-ssllabs');
+
+const MAX_DURATION_SECONDS = 120;
+const LOCAL_DOMAINS = ['localhost', '127.0.0.1'];
+
+const isLocalDomain = host => LOCAL_DOMAINS.includes(host);
+
+class SslGrade extends Gatherer {
+  afterPass(options) {
+    const driver = options.driver;
+    const timeout = options._testTimeout || MAX_DURATION_SECONDS * 1000;
+
+    const sslTestPromise = driver.evaluateAsync('window.location.host')
+        .then(host => new Promise((resolve, reject) => {
+            if (isLocalDomain(host)) {
+                reject(new Error('Domain must be available over the public internet to test SSL.'));
+            }
+
+            ssllabs.scan({ 
+                host, 
+                fromCache: 'off',
+                startNew: 'on',
+            }, (err, result) => {
+                err ? reject(err) : resolve(result);
+            });
+        }));
+
+    let sslTestTimeout;
+    const timeoutPromise = new Promise((resolve, reject) => {
+        sslTestTimeout = setTimeout(_ => {
+            reject(new Error(`SSL test took over ${MAX_DURATION_SECONDS} seconds.`));
+        }, timeout);
+    });
+
+    return Promise.race([
+        sslTestPromise,
+        timeoutPromise
+    ]).then(result => {
+      // Clear timeout. No effect if it won, no need to wait if it lost.
+      clearTimeout(sslTestTimeout);
+      return result;
+    }).catch(err => {
+      clearTimeout(sslTestTimeout);
+      throw err;
+    });
+  }
+}
+
+module.exports = SslGrade;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "dependencies": {
     "lighthouse": "^2.3.0",
+    "node-ssllabs": "0.5.0",
     "request": "^2.81.0",
     "request-promise": "^4.2.1"
   }


### PR DESCRIPTION
Don't merge this PR yet. Things that need to be discussed:
* error handling
* max duration of ssl test

Result if passing (used `https://rabobank.nl`):

<img width="803" alt="screen shot 2017-08-13 at 16 55 58" src="https://user-images.githubusercontent.com/1516059/29250782-deec639c-8048-11e7-9c06-28b9b14862fe.png">

Result if failing due to poor grade (used `https://www.voorhoede.nl`):

<img width="801" alt="screen shot 2017-08-13 at 16 57 19" src="https://user-images.githubusercontent.com/1516059/29250786-099ae7a8-8049-11e7-9082-4b6d1c0bf39a.png">

Result if failing due to error (used localhost):

<img width="800" alt="screen shot 2017-08-13 at 16 56 20" src="https://user-images.githubusercontent.com/1516059/29250793-1f38a0b4-8049-11e7-8668-99ac169c611d.png">
